### PR TITLE
fix: DemoApplicationTests and IntegrationTests

### DIFF
--- a/src/test/kotlin/demo/DemoApplicationTests.kt
+++ b/src/test/kotlin/demo/DemoApplicationTests.kt
@@ -33,7 +33,7 @@ class DemoApplicationTests(
 
     companion object {
         @Container
-        val container = postgres("postgres:13-alpine") {
+        val container = postgres("13-alpine") {
             withDatabaseName("db")
             withUsername("user")
             withPassword("password")

--- a/src/test/kotlin/demo/IntegrationTests.kt
+++ b/src/test/kotlin/demo/IntegrationTests.kt
@@ -9,7 +9,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 class IntegrationTests {
     companion object {
         @Container
-        val container = postgres("postgres:13-alpine") {
+        val container = postgres("13-alpine") {
             withDatabaseName("db")
             withUsername("user")
             withPassword("password")


### PR DESCRIPTION
Fixed a bug, where the postgres container failed to start, due to the fact that "postgres:" is already prepended in the extension function, resulting in the image not being fetched corectly, i.e. the program was looking for "postgres:postgres:13-alpine" 